### PR TITLE
V3.4.1 Release Candidate

### DIFF
--- a/bin/labkey_upload_blast_fasta.py
+++ b/bin/labkey_upload_blast_fasta.py
@@ -62,7 +62,7 @@ def main():
     parser.add_argument("--labkey-project-name", required=True)
     parser.add_argument("--labkey-api-key", required=True)
     parser.add_argument("--labkey-schema", required=True)
-    parser.add_argument("--table-name", default="fasta_hits_test_nvd2")
+    parser.add_argument("--table-name", default="fasta_hits_test")
     parser.add_argument(
         "--insert-batch-size",
         type=int,

--- a/bin/labkey_upload_blast_fasta.py
+++ b/bin/labkey_upload_blast_fasta.py
@@ -15,19 +15,33 @@ from datetime import datetime
 from py_nvd.labkey_io import PartialInsertError, insert_records, rows_present
 
 
-def sample_already_uploaded(query_api, schema, table, experiment, sample_id) -> bool:
-    """True if the FASTA list already holds this sample's contigs (its ledger).
+def combo_already_uploaded(
+    query_api,
+    schema,
+    table,
+    experiment,
+    sample_id,
+    query_class,
+) -> bool:
+    """True if the FASTA list already holds this unit's rows (its ledger).
 
-    FASTA is contig-only: one unit per sample, so presence is checked by
-    (experiment, sample_id) alone (no query_class). Reuses the guard script's
-    filter fallbacks (QueryFilter objects, then filter-string syntax) so this
-    still works against older labkey-api-python versions.
+    The unit is (experiment, sample_id, query_class), matching the BLAST hits
+    upload. Keying on (experiment, sample_id) alone was correct only while the
+    list held contigs: now that every queried class is uploaded, the contig
+    batch would make each later class for that sample look already uploaded and
+    its rows would be dropped with no error. Reuses the guard script's filter
+    fallbacks (QueryFilter objects, then filter-string syntax) so this still
+    works against older labkey-api-python versions.
     """
     return rows_present(
         query_api,
         schema,
         table,
-        {"experiment": experiment, "sample_id": sample_id},
+        {
+            "experiment": experiment,
+            "sample_id": sample_id,
+            "query_class": query_class,
+        },
     )
 
 
@@ -43,6 +57,7 @@ def main():
     parser = argparse.ArgumentParser(description="Upload FASTA CSVs to LabKey.")
     parser.add_argument("--experiment-id", required=True)
     parser.add_argument("--sample-id", required=True)
+    parser.add_argument("--query-class", required=True)
     parser.add_argument("--labkey-server", required=True)
     parser.add_argument("--labkey-project-name", required=True)
     parser.add_argument("--labkey-api-key", required=True)
@@ -63,6 +78,7 @@ def main():
         f"LabKey FASTA Upload Log - {datetime.now()}",
         f"Experiment ID: {args.experiment_id}",
         f"Sample: {args.sample_id}",
+        f"Query class: {args.query_class}",
         f"Server: {args.labkey_server}",
         f"Project: {args.labkey_project_name}",
         f"Target Table: {args.table_name}",
@@ -91,19 +107,20 @@ def main():
             "No LabKey credentials provided - running in simulation mode",
         )
 
-    # The destination list is its own completion ledger. If this sample already
-    # has rows there, a prior run already uploaded its contigs: skip
-    # re-inserting rather than risk duplicating the FASTA list.
-    if upload_enabled and sample_already_uploaded(
+    # The destination list is its own completion ledger. If this
+    # (sample_id, query_class) unit already has rows there, a prior run
+    # uploaded it: skip re-inserting rather than duplicate the FASTA list.
+    if upload_enabled and combo_already_uploaded(
         api.query,
         args.labkey_schema,
         args.table_name,
         int(args.experiment_id),
         args.sample_id,
+        args.query_class,
     ):
         log_entries.append(
-            f"SKIP: sample already uploaded (exp={args.experiment_id}, "
-            f"sample={args.sample_id}); no insert.",
+            f"SKIP: combo already uploaded (exp={args.experiment_id}, "
+            f"sample={args.sample_id}, query_class={args.query_class}); no insert.",
         )
         _write_log(log_entries)
         return
@@ -157,7 +174,9 @@ def main():
                                 f"The destination list is keyed on row presence, "
                                 f"so a retry will treat "
                                 f"experiment={args.experiment_id} "
-                                f"sample={args.sample_id} as already uploaded and "
+                                f"sample={args.sample_id} "
+                                f"query_class={args.query_class} as already "
+                                f"uploaded and "
                                 f"silently skip the remaining "
                                 f"{e.total_rows - e.rows_committed} rows.\n"
                                 f"Delete that unit's rows from "
@@ -167,7 +186,8 @@ def main():
                             _write_log(log_entries)
                             print(
                                 f"ERROR: LabKey insert failed for "
-                                f"sample={args.sample_id} after committing "
+                                f"sample={args.sample_id} query_class={args.query_class} "
+                                f"after committing "
                                 f"{e.rows_committed}/{e.total_rows} rows; delete "
                                 f"this unit's rows before retrying: {e!s}",
                                 file=sys.stderr,
@@ -185,7 +205,9 @@ def main():
                                 file=sys.stderr,
                             )
                             sys.exit(1)
-                        log_entries.append(f"  Upload: SUCCESS ({len(records)} records)")
+                        log_entries.append(
+                            f"  Upload: SUCCESS ({len(records)} records)"
+                        )
                         total_records_uploaded += record_count
 
                     else:

--- a/bin/test_labkey_upload_blast_fasta.py
+++ b/bin/test_labkey_upload_blast_fasta.py
@@ -111,8 +111,8 @@ def test_main_exits_nonzero_when_insert_fails(tmp_path, monkeypatch, capsys) -> 
     """A failed atomic insert must hard-fail the run, not report success."""
     csv_path = tmp_path / "s1_fasta.csv"
     csv_path.write_text(
-        "experiment,sample_id,contig_id,contig_sequence,notes,nextflow_run_id\n"
-        "7,s1,contig_1,ACGT,,run1\n",
+        "experiment,sample_id,query_class,qseqid,query_sequence,notes,nextflow_run_id\n"
+        "7,s1,single_read,nvdReadQuery_s1_000001,ACGT,,run1\n",
     )
 
     fake_query = _FakeQueryAPI(rows=[], insert_error=RuntimeError("insert boom"))
@@ -138,8 +138,8 @@ def test_main_skip_present_sample_exits_zero(tmp_path, monkeypatch) -> None:
     """A unit already present in the destination list is a no-op success, not a failure."""
     csv_path = tmp_path / "s1_fasta.csv"
     csv_path.write_text(
-        "experiment,sample_id,contig_id,contig_sequence,notes,nextflow_run_id\n"
-        "7,s1,contig_1,ACGT,,run1\n",
+        "experiment,sample_id,query_class,qseqid,query_sequence,notes,nextflow_run_id\n"
+        "7,s1,single_read,nvdReadQuery_s1_000001,ACGT,,run1\n",
     )
 
     fake_query = _FakeQueryAPI(rows=[{"Key": 1}])
@@ -193,7 +193,7 @@ def test_read_class_uploads_when_contigs_are_already_present(
     """A sample's uploaded contigs must not suppress its read query classes."""
     csv_path = tmp_path / "s1_fasta.csv"
     csv_path.write_text(
-        "experiment,sample_id,query_class,contig_id,contig_sequence,notes,"
+        "experiment,sample_id,query_class,qseqid,query_sequence,notes,"
         "nextflow_run_id\n"
         "7,s1,single_read,nvdReadQuery_s1_000001,ACGT,,run1\n",
     )
@@ -252,7 +252,7 @@ def test_partial_insert_guidance_names_the_query_class(
     """
     csv_path = tmp_path / "s1_fasta.csv"
     csv_path.write_text(
-        "experiment,sample_id,query_class,contig_id,contig_sequence,notes,"
+        "experiment,sample_id,query_class,qseqid,query_sequence,notes,"
         "nextflow_run_id\n"
         "7,s1,single_read,nvdReadQuery_s1_000001,ACGT,,run1\n"
         "7,s1,single_read,nvdReadQuery_s1_000002,TTGC,,run1\n",

--- a/bin/test_labkey_upload_blast_fasta.py
+++ b/bin/test_labkey_upload_blast_fasta.py
@@ -1,10 +1,10 @@
-"""Tests for deduping the contig FASTA LabKey upload by (experiment, sample_id)."""
+"""Tests for deduping the query FASTA LabKey upload by (experiment, sample_id, query_class)."""
 
 import sys
 
 import labkey.api_wrapper
 import pytest
-from labkey_upload_blast_fasta import insert_records, main, sample_already_uploaded
+from labkey_upload_blast_fasta import combo_already_uploaded, insert_records, main
 
 
 class _FakeQuery:
@@ -17,16 +17,33 @@ class _FakeQuery:
         return {"rows": self._rows}
 
 
-def test_sample_present_is_detected() -> None:
-    assert sample_already_uploaded(_FakeQuery([{"Key": 1}]), "lists", "fasta", 7, "s1") is True
+def test_combo_present_is_detected() -> None:
+    q = _FakeQuery([{"Key": 1}])
+    assert combo_already_uploaded(q, "lists", "fasta", 7, "s1", "single_read") is True
 
 
-def test_sample_absent_is_detected() -> None:
+def test_combo_absent_is_detected() -> None:
     q = _FakeQuery([])
-    assert sample_already_uploaded(q, "lists", "fasta", 7, "s1") is False
+    assert combo_already_uploaded(q, "lists", "fasta", 7, "s1", "single_read") is False
     (call,) = q.calls
     assert any("experiment" in str(f) for f in call["filter_array"])
     assert any("sample_id" in str(f) for f in call["filter_array"])
+
+
+def test_guard_keys_on_query_class() -> None:
+    """A sample's contigs being present must not mask an unuploaded read class.
+
+    The list is its own completion ledger. Keyed on (experiment, sample_id)
+    alone, the contig batch would make every later query class for that sample
+    look already uploaded, and its rows would be dropped without an error.
+    """
+    q = _FakeQuery([])
+    assert (
+        combo_already_uploaded(q, "lists", "fasta", 7, "s1", "overlap_merged_pair")
+        is False
+    )
+    (call,) = q.calls
+    assert any("query_class" in str(f) for f in call["filter_array"])
 
 
 def test_insert_records_propagates_api_failure() -> None:
@@ -75,6 +92,8 @@ def _cli_argv(table_name: str = "fasta") -> list[str]:
         "7",
         "--sample-id",
         "s1",
+        "--query-class",
+        "single_read",
         "--labkey-server",
         "https://example.org",
         "--labkey-project-name",
@@ -98,7 +117,9 @@ def test_main_exits_nonzero_when_insert_fails(tmp_path, monkeypatch, capsys) -> 
 
     fake_query = _FakeQueryAPI(rows=[], insert_error=RuntimeError("insert boom"))
     monkeypatch.setattr(
-        labkey.api_wrapper, "APIWrapper", _fake_api_wrapper_class(fake_query),
+        labkey.api_wrapper,
+        "APIWrapper",
+        _fake_api_wrapper_class(fake_query),
     )
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(sys, "argv", _cli_argv())
@@ -114,7 +135,7 @@ def test_main_exits_nonzero_when_insert_fails(tmp_path, monkeypatch, capsys) -> 
 
 
 def test_main_skip_present_sample_exits_zero(tmp_path, monkeypatch) -> None:
-    """A sample already present in the destination list is a no-op success, not a failure."""
+    """A unit already present in the destination list is a no-op success, not a failure."""
     csv_path = tmp_path / "s1_fasta.csv"
     csv_path.write_text(
         "experiment,sample_id,contig_id,contig_sequence,notes,nextflow_run_id\n"
@@ -123,7 +144,9 @@ def test_main_skip_present_sample_exits_zero(tmp_path, monkeypatch) -> None:
 
     fake_query = _FakeQueryAPI(rows=[{"Key": 1}])
     monkeypatch.setattr(
-        labkey.api_wrapper, "APIWrapper", _fake_api_wrapper_class(fake_query),
+        labkey.api_wrapper,
+        "APIWrapper",
+        _fake_api_wrapper_class(fake_query),
     )
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(sys, "argv", _cli_argv())
@@ -131,5 +154,123 @@ def test_main_skip_present_sample_exits_zero(tmp_path, monkeypatch) -> None:
     main()  # must return normally (implicit exit 0), never raise SystemExit
 
     log_text = (tmp_path / "fasta_labkey_upload.log").read_text()
-    assert "SKIP: sample already uploaded" in log_text
+    assert "SKIP: combo already uploaded" in log_text
+    assert "query_class=single_read" in log_text
     assert fake_query.inserted_rows is None
+
+
+class _LedgerQueryAPI:
+    """Query API backed by rows that actually honour the filters it is given.
+
+    The destination list is its own completion ledger, and LabKey returns every
+    row matching the filters supplied. A fake that ignored filters could not
+    distinguish "this unit is uploaded" from "some other unit for this sample
+    is", which is the exact distinction these tests exist to pin.
+    """
+
+    def __init__(self, rows):
+        self._rows = rows
+        self.inserted_rows = None
+
+    def select_rows(self, **kwargs):
+        wanted = {f.column_name: f.value for f in kwargs["filter_array"]}
+        matches = [
+            row
+            for row in self._rows
+            if all(row.get(column) == value for column, value in wanted.items())
+        ]
+        return {"rows": matches[:1]}
+
+    def insert_rows(self, **kwargs):
+        self.inserted_rows = kwargs.get("rows")
+        return {"rows": [{"Key": 1}]}
+
+
+def test_read_class_uploads_when_contigs_are_already_present(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """A sample's uploaded contigs must not suppress its read query classes."""
+    csv_path = tmp_path / "s1_fasta.csv"
+    csv_path.write_text(
+        "experiment,sample_id,query_class,contig_id,contig_sequence,notes,"
+        "nextflow_run_id\n"
+        "7,s1,single_read,nvdReadQuery_s1_000001,ACGT,,run1\n",
+    )
+
+    fake_query = _LedgerQueryAPI(
+        rows=[
+            {
+                "experiment": 7,
+                "sample_id": "s1",
+                "query_class": "short_assembly_contig",
+            },
+        ],
+    )
+    monkeypatch.setattr(
+        labkey.api_wrapper,
+        "APIWrapper",
+        _fake_api_wrapper_class(fake_query),
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "argv", _cli_argv())
+
+    main()
+
+    assert fake_query.inserted_rows is not None, (
+        "single_read rows were dropped because this sample's contigs were "
+        "already in the list"
+    )
+
+
+class _PartialInsertQueryAPI:
+    """Commits the first batch, then fails — the partial-commit path."""
+
+    def __init__(self):
+        self.batches_committed = 0
+
+    def select_rows(self, **kwargs):
+        return {"rows": []}
+
+    def insert_rows(self, **kwargs):
+        if self.batches_committed >= 1:
+            raise RuntimeError("insert boom")
+        self.batches_committed += 1
+        return {"rows": [{"Key": 1}]}
+
+
+def test_partial_insert_guidance_names_the_query_class(
+    tmp_path,
+    monkeypatch,
+    capsys,
+) -> None:
+    """Committed-but-incomplete rows must identify the unit to clear.
+
+    The ledger is keyed on (experiment, sample_id, query_class), so an operator
+    told only the sample would not know which of its batches to delete before
+    re-running.
+    """
+    csv_path = tmp_path / "s1_fasta.csv"
+    csv_path.write_text(
+        "experiment,sample_id,query_class,contig_id,contig_sequence,notes,"
+        "nextflow_run_id\n"
+        "7,s1,single_read,nvdReadQuery_s1_000001,ACGT,,run1\n"
+        "7,s1,single_read,nvdReadQuery_s1_000002,TTGC,,run1\n",
+    )
+
+    fake_query = _PartialInsertQueryAPI()
+    monkeypatch.setattr(
+        labkey.api_wrapper,
+        "APIWrapper",
+        _fake_api_wrapper_class(fake_query),
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(sys, "argv", [*_cli_argv(), "--insert-batch-size", "1"])
+
+    with pytest.raises(SystemExit) as excinfo:
+        main()
+    assert excinfo.value.code == 1
+
+    log_text = (tmp_path / "fasta_labkey_upload.log").read_text()
+    assert "query_class=single_read" in log_text
+    assert "query_class=single_read" in capsys.readouterr().err

--- a/bin/test_validate_labkey.py
+++ b/bin/test_validate_labkey.py
@@ -46,7 +46,13 @@ def test_prepared_fasta_uses_query_scoped_column_names() -> None:
 
 
 def test_validator_expects_the_same_query_scoped_columns() -> None:
-    """A writer/validator mismatch fails the run, so pin them together."""
+    """The declared schema must use the same names the pipeline writes.
+
+    validate_labkey.py never reads blast_fasta_fields; it validates by inserting
+    the dummy row below. The list is the declared schema, and
+    test_dummy_row_covers_the_validated_schema is what gives it teeth by holding
+    the live dummy to it.
+    """
     assert "Qseqid" in blast_fasta_fields
     assert "Query Sequence" in blast_fasta_fields
     assert "Contig Id" not in blast_fasta_fields
@@ -61,5 +67,9 @@ def test_qseqid_matches_the_hits_list_column_name() -> None:
 
 
 def test_dummy_row_covers_the_validated_schema() -> None:
-    """The dummy insert proves the real schema accepts a row, so it must be complete."""
+    """The dummy insert is the only real check, so it must cover the schema.
+
+    A dummy narrower than the declared list proves less than it appears to: the
+    columns it omits are never exercised against the real list.
+    """
     assert _dummy_row_keys() == set(blast_fasta_fields)

--- a/bin/test_validate_labkey.py
+++ b/bin/test_validate_labkey.py
@@ -1,0 +1,65 @@
+"""Tests for the FASTA list schema validate_labkey.py checks before upload."""
+
+import ast
+import re
+from pathlib import Path
+
+from prepare_blast_labkey import COLUMN_RENAMES, LABKEY_INPUT_COLUMNS
+from validate_labkey import blast_fasta_fields
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _prepared_fasta_fieldnames() -> list[str]:
+    """Columns LABKEY_PREPARE_FASTA writes, read out of the process script.
+
+    The prep step is inline Python inside modules/labkey.nf, so there is no
+    import seam. Reading the literal keeps the pipeline's writer and the
+    validator's expectations pinned to each other.
+    """
+    text = (ROOT / "modules" / "labkey.nf").read_text(encoding="utf-8")
+    match = re.search(r"fieldnames = (\[[^\]]*\])", text, re.DOTALL)
+    assert match is not None, "LABKEY_PREPARE_FASTA fieldnames literal not found"
+    return ast.literal_eval(re.sub(r"\s+", " ", match.group(1)))
+
+
+def _dummy_row_keys() -> set[str]:
+    """Keys of the blast_fasta dummy row validate_labkey.py inserts."""
+    text = (ROOT / "bin" / "validate_labkey.py").read_text(encoding="utf-8")
+    block = re.search(
+        r'elif args\.type == "blast_fasta":\s*dummy = \{(.*?)\}',
+        text,
+        re.DOTALL,
+    )
+    assert block is not None, "blast_fasta dummy row not found"
+    return set(re.findall(r'"([^"]+)":', block.group(1)))
+
+
+def test_prepared_fasta_uses_query_scoped_column_names() -> None:
+    """The list holds every queried class, so contig-scoped names are wrong."""
+    fieldnames = _prepared_fasta_fieldnames()
+
+    assert "qseqid" in fieldnames
+    assert "query_sequence" in fieldnames
+    assert "contig_id" not in fieldnames
+    assert "contig_sequence" not in fieldnames
+
+
+def test_validator_expects_the_same_query_scoped_columns() -> None:
+    """A writer/validator mismatch fails the run, so pin them together."""
+    assert "Qseqid" in blast_fasta_fields
+    assert "Query Sequence" in blast_fasta_fields
+    assert "Contig Id" not in blast_fasta_fields
+    assert "Contig Sequence" not in blast_fasta_fields
+
+
+def test_qseqid_matches_the_hits_list_column_name() -> None:
+    """The two lists join on this column, so the name must agree exactly."""
+    assert "qseqid" in LABKEY_INPUT_COLUMNS
+    assert "qseqid" not in COLUMN_RENAMES
+    assert "qseqid" in _prepared_fasta_fieldnames()
+
+
+def test_dummy_row_covers_the_validated_schema() -> None:
+    """The dummy insert proves the real schema accepts a row, so it must be complete."""
+    assert _dummy_row_keys() == set(blast_fasta_fields)

--- a/bin/validate_labkey.py
+++ b/bin/validate_labkey.py
@@ -38,8 +38,8 @@ blast_fasta_fields = [
     "Experiment",
     "Sample Id",
     "Query Class",
-    "Contig Id",
-    "Contig Sequence",
+    "Qseqid",
+    "Query Sequence",
     "Notes",
     "Snakemake Run Id",
 ]
@@ -196,8 +196,9 @@ def main() -> None:
         dummy = {
             "Experiment": unique_experiment_id,
             "Sample Id": "__DUMMY__SAMPLE__",
-            "Contig Id": "__DUMMY__CONTIG__",
-            "Contig Sequence": "ATGCATGC",
+            "Query Class": "__DUMMY__CLASS__",
+            "Qseqid": "__DUMMY__QUERY__",
+            "Query Sequence": "ATGCATGC",
             "Notes": 0.0,
             "Snakemake Run Id": "__DUMMY__SMK__",
         }

--- a/bin/validate_labkey.py
+++ b/bin/validate_labkey.py
@@ -37,6 +37,7 @@ blast_fields = [
 blast_fasta_fields = [
     "Experiment",
     "Sample Id",
+    "Query Class",
     "Contig Id",
     "Contig Sequence",
     "Notes",

--- a/lib/py_nvd/__init__.py
+++ b/lib/py_nvd/__init__.py
@@ -1,6 +1,6 @@
 """NVD CLI and pipeline helper library."""
 
-__version__ = "3.4.0"
+__version__ = "3.4.1"
 
 # Re-export key modules for convenient access.
 from py_nvd import models, params, paths, presets, taxonomy

--- a/modules/labkey.nf
+++ b/modules/labkey.nf
@@ -176,17 +176,23 @@ process LABKEY_CONCAT_ALL_SAMPLE_BLAST_RESULTS {
 }
 
 process LABKEY_PREPARE_FASTA {
-    tag "$meta"
+    /* Build one LabKey FASTA CSV per (sample_id, query_class) batch.
+
+       contig_id stays the raw qseqid so it still joins to the BLAST hits list;
+       the class it belongs to travels in its own query_class column, the way
+       the hits list has always carried it. */
+
+    tag "$meta.$query_class"
     label 'low'
 
     input:
-    tuple val(meta), path(fasta), val(output_name)
+    tuple val(meta), val(query_class), path(fasta)
     val experiment_id
     val run_id
     val validation_complete
 
     output:
-    tuple val(meta), path("${output_name}"), emit: csv
+    tuple val(meta), val(query_class), path("${meta}.${query_class}_fasta_labkey.csv"), emit: csv
 
     script:
     """
@@ -195,12 +201,14 @@ process LABKEY_PREPARE_FASTA {
     import csv
     from Bio import SeqIO
 
+    output_name = '${meta}.${query_class}_fasta_labkey.csv'
     fasta_data = []
 
     for record in SeqIO.parse('${fasta}', 'fasta'):
         labkey_row = {
             'experiment': ${experiment_id},
             'sample_id': '${meta}',
+            'query_class': '${query_class}',
             'contig_id': record.id,
             'contig_sequence': str(record.seq),
             'notes': '',
@@ -209,14 +217,14 @@ process LABKEY_PREPARE_FASTA {
         fasta_data.append(labkey_row)
 
     if fasta_data:
-        with open('${output_name}', 'w') as f:
-            fieldnames = ['experiment', 'sample_id', 'contig_id',
+        with open(output_name, 'w') as f:
+            fieldnames = ['experiment', 'sample_id', 'query_class', 'contig_id',
                          'contig_sequence', 'notes', 'nextflow_run_id']
             writer = csv.DictWriter(f, fieldnames=fieldnames)
             writer.writeheader()
             writer.writerows(fasta_data)
     else:
-        open('${output_name}', 'w').close()
+        open(output_name, 'w').close()
     """
 }
 
@@ -252,14 +260,14 @@ process LABKEY_UPLOAD_BLAST {
 }
 
 process LABKEY_UPLOAD_FASTA {
-    tag "${sample_id}"
+    tag "${sample_id}, ${query_class}"
     label 'low'
     secret 'LABKEY_API_KEY'
     errorStrategy 'retry'
     maxRetries 2
 
     input:
-    tuple val(sample_id), path(csv_file)
+    tuple val(sample_id), val(query_class), path(csv_file)
     val experiment_id
 
     output:
@@ -270,6 +278,7 @@ process LABKEY_UPLOAD_FASTA {
     labkey_upload_blast_fasta.py \
         --experiment-id '${experiment_id}' \
         --sample-id '${sample_id}' \
+        --query-class '${query_class}' \
         --labkey-server '${params.labkey_server}' \
         --labkey-project-name '${params.labkey_project_name}' \
         --labkey-api-key \$LABKEY_API_KEY \

--- a/modules/labkey.nf
+++ b/modules/labkey.nf
@@ -178,9 +178,9 @@ process LABKEY_CONCAT_ALL_SAMPLE_BLAST_RESULTS {
 process LABKEY_PREPARE_FASTA {
     /* Build one LabKey FASTA CSV per (sample_id, query_class) batch.
 
-       contig_id stays the raw qseqid so it still joins to the BLAST hits list;
-       the class it belongs to travels in its own query_class column, the way
-       the hits list has always carried it. */
+       qseqid keeps the BLAST hits list's own column name and its raw value,
+       so the two lists join on identically named columns throughout. The class
+       travels in query_class, as it always has on the hits side. */
 
     tag "$meta.$query_class"
     label 'low'
@@ -209,8 +209,8 @@ process LABKEY_PREPARE_FASTA {
             'experiment': ${experiment_id},
             'sample_id': '${meta}',
             'query_class': '${query_class}',
-            'contig_id': record.id,
-            'contig_sequence': str(record.seq),
+            'qseqid': record.id,
+            'query_sequence': str(record.seq),
             'notes': '',
             'nextflow_run_id': '${run_id}'
         }
@@ -218,8 +218,8 @@ process LABKEY_PREPARE_FASTA {
 
     if fasta_data:
         with open(output_name, 'w') as f:
-            fieldnames = ['experiment', 'sample_id', 'query_class', 'contig_id',
-                         'contig_sequence', 'notes', 'nextflow_run_id']
+            fieldnames = ['experiment', 'sample_id', 'query_class', 'qseqid',
+                         'query_sequence', 'notes', 'nextflow_run_id']
             writer = csv.DictWriter(f, fieldnames=fieldnames)
             writer.writeheader()
             writer.writerows(fasta_data)

--- a/nextflow.config
+++ b/nextflow.config
@@ -338,7 +338,7 @@ manifest {
     homePage      = ''
     mainScript    = 'main.nf'
     defaultBranch = 'main'
-    version       = '3.4.0'
+    version       = '3.4.1'
     description   = ''
     author        = ''
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
   { name = "William Gardner", email = "wkgardner@wisc.edu" },
 ]
 requires-python = ">= 3.11, < 3.14"
-version = "3.4.0"
+version = "3.4.1"
 dependencies = [
   "altair>=6.1.0",
   "biopython>=1.85",

--- a/subworkflows/lims_integration.nf
+++ b/subworkflows/lims_integration.nf
@@ -60,19 +60,22 @@ workflow LIMS_INTEGRATION {
         tuple(sample_id, query_class, blast_tsv)
     }
 
-    // FASTA insertion and the combined WebDAV upload remain synchronized by
-    // this inner join. Contigs are per-sample, so this joins against the
-    // per-sample stacked BLAST TSV (not the per-batch stream) to keep both
-    // downstream of this join running once per sample. Read-only samples
-    // intentionally skip both for now.
-    ch_all_sample_data = ch_labkey_sample_blast_results
+    // The combined WebDAV upload pairs a sample's stacked BLAST TSV with its
+    // contig FASTA, so it keeps this inner join: both sides are per-sample, and
+    // a sample with no contigs has nothing to combine. LabKey FASTA rows no
+    // longer come through here — see ch_query_fasta_split below.
+    ch_webdav_upload = ch_labkey_sample_blast_results
         .join(ch_labkey_contigs, by: 0)
 
-    ch_split = ch_all_sample_data
-        .multiMap { sample_id, blast_tsv, fasta ->
-            def fasta_output = "${sample_id}_fasta_labkey.csv"
-            webdav_upload: [sample_id, blast_tsv, fasta]
-            fasta_labkey: [sample_id, fasta, fasta_output]
+    // FASTA rows now follow the BLAST hits pattern: one batch per
+    // (sample_id, query_class), covering every class that was actually
+    // queried rather than contigs alone. A queue channel cannot be consumed
+    // twice, so the WebDAV artifact upload and the LabKey row insert each take
+    // their own branch of the same stream.
+    ch_query_fasta_split = ch_labkey_query_fastas
+        .multiMap { sample_id, query_class, fasta ->
+            webdav: tuple(sample_id, query_class, fasta)
+            labkey_rows: tuple(sample_id, query_class, fasta)
         }
 
     LABKEY_PREPARE_BLAST(
@@ -82,21 +85,20 @@ workflow LIMS_INTEGRATION {
     )
 
     LABKEY_WEBDAV_UPLOAD_BLAST(
-        ch_split.webdav_upload,
+        ch_webdav_upload,
         ch_validation_gate,
     )
 
     // Per-read-type query FASTAs (contig, merged, single) — the sequences
-    // that were actually BLASTed — published as file artifacts. Un-guarded:
-    // there is no corresponding LabKey list row, so no validation gate is
-    // required beyond params.labkey being enabled.
+    // that were actually BLASTed — published as file artifacts alongside the
+    // LabKey rows built from the same batches.
     LABKEY_WEBDAV_UPLOAD_QUERY_FASTA(
-        ch_labkey_query_fastas,
+        ch_query_fasta_split.webdav,
         ch_validation_gate,
     )
 
     LABKEY_PREPARE_FASTA(
-        ch_split.fasta_labkey,
+        ch_query_fasta_split.labkey_rows,
         experiment_id,
         run_id,
         ch_validation_gate,

--- a/uv.lock
+++ b/uv.lock
@@ -1585,7 +1585,7 @@ wheels = [
 
 [[package]]
 name = "nvd"
-version = "3.4.0"
+version = "3.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "altair" },


### PR DESCRIPTION
## Summary

With the addition of query_classes on by default the blast hits LIMS integration was publishing everything but FASTA queries were still being filtered down to only contigs. `LIMS_INTEGRATION` inner-joined the per-sample BLAST TSV against the contig FASTA channel, so read query classes produced no sequence rows and samples with no contigs dropped out entirely. Since v3.4.0 made read querying the default, hits rows for `overlap_merged_pair` and `single_read` have no matching sequences when looking at the LIMS tables.

## Changes

- FASTA rows upload eagerly per `(sample_id, query_class)`, all four queried classes
- Columns renamed `contig_id`/`contig_sequence` → `qseqid`/`query_sequence`. `qseqid` matches the hits list, so the two now join on identically named columns throughout. Values are unchanged.
- Version bump to 3.4.1

## Testing

- 7 new unit tests; full fast suite green (3 pre-existing `test_db.py` env failures unchanged)
- Real-LabKey e2e against our LIMS tables.
